### PR TITLE
fix NIR smoothing bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+----------
+
+Fixed
+~~~~~
+- **Adding-doubling solver: incorrect albedo at SZA > ~55° for ice layers**
+  (`#111 <https://github.com/jmcook1186/biosnicar-py/issues/111>`_).
+  At oblique solar angles the direct beam can exceed the critical angle at
+  ice's anomalous-dispersion bands (~2.93–3.09 µm), triggering total internal
+  reflection (TIR) and producing a physically correct albedo of 1.0 in those
+  bands. The Savitzky-Golay smoothing filter, applied as a post-processing
+  step, treated these step discontinuities as noise and produced large ringing
+  artefacts: values inside the TIR region were undershooting to 0.67–0.95, and
+  the adjacent non-TIR transition bands were falsely elevated to 0.05–0.33.
+  The fix identifies TIR bands before smoothing (``np.isclose(albedo, 1.0)``)
+  and expands that mask outward by ``window_size // 2`` bands using
+  ``scipy.ndimage.binary_dilation``. The raw solver output is preserved in
+  this guard zone so the SG polynomial is never fitted across the
+  discontinuity. The physical step at the TIR boundary—present in the Matlab
+  reference (Whicker et al. 2022)—is reproduced correctly; the only
+  transitions introduced at guard-zone edges are O(10⁻⁴) in magnitude and
+  visually indistinguishable from the surrounding smoothed spectrum.
+
 2.1.0 - (2023-07-20)
 -------------
 

--- a/biosnicar/rt_solvers/adding_doubling_solver.py
+++ b/biosnicar/rt_solvers/adding_doubling_solver.py
@@ -30,6 +30,7 @@ solid ice layers and fresnel reflection are included.
 """
 
 import numpy as np
+from scipy.ndimage import binary_dilation
 from biosnicar.rt_solvers.smoothing import apply_smoothing_function
 
 from biosnicar.classes.outputs import Outputs
@@ -240,7 +241,20 @@ def adding_doubling_solver(tau, ssa, g, L_snw, ice, illumination, model_config):
     )
 
     if model_config.smooth:
-        outputs.albedo = apply_smoothing_function(outputs.albedo, model_config)
+        # Identify bands in total internal reflection (TIR) before smoothing.
+        # At SZA > ~55° the direct beam exceeds the critical angle at ice's
+        # anomalous-dispersion bands (~2.93–3.09 µm), giving albedo = 1.0.
+        # The Savitzky-Golay filter produces large ringing artefacts across
+        # these step discontinuities, undershooting inside TIR and falsely
+        # elevating adjacent bands.  We preserve the raw solver output in the
+        # TIR bands and a guard zone of window_size // 2 bands on each side,
+        # so the polynomial is never fitted across the discontinuity.
+        raw = outputs.albedo.copy()
+        tir_guard = binary_dilation(
+            np.isclose(raw, 1.0), iterations=model_config.window_size // 2
+        )
+        smoothed = apply_smoothing_function(raw, model_config)
+        outputs.albedo = np.where(tir_guard, raw, smoothed)
 
     # Final clamp to [0, 1].  The two-stream approximation can produce
     # slightly unphysical albedo in bands with extreme optical depth

--- a/tests/test_snicar.py
+++ b/tests/test_snicar.py
@@ -686,5 +686,103 @@ def test_var_fuzzer(rds, rho, zen, dust, algae, fuzz, input_file):
     return
 
 
+def test_tir_smoothing_high_sza():
+    """Regression for #111: SG filter must not distort TIR albedo at SZA > ~55°.
+
+    At oblique solar angles the direct beam can exceed the critical angle at
+    ice anomalous-dispersion bands (~2.93–3.09 µm), producing physically exact
+    albedo = 1.0 (total internal reflection, TIR).  The SG smoothing filter
+    previously undershooting TIR bands (0.67–0.95 instead of 1.0) and falsely
+    elevated adjacent guard bands (~0.33 instead of ~0.0004).
+
+    Checks:
+    - TIR bands remain exactly 1.0 after smoothing.
+    - Guard bands (within window // 2 of TIR) deviate < 0.01 from raw values.
+    - All albedo values lie in [0, 1].
+    """
+    from scipy.ndimage import binary_dilation
+
+    input_file = "biosnicar/inputs.yaml"
+    half_w = 7 // 2  # matches default window_size=7
+
+    ice, illumination, rt_config, model_config, plot_config, impurities = setup_snicar(
+        input_file
+    )
+    # Solid ice with Fresnel surface — the only configuration that produces TIR
+    ice.layer_type = [1]
+    ice.dz = [0.02]
+    ice.rds = [100]
+    ice.rho = [300]
+    ice.nbr_lyr = 1
+    ice.lwc = [0]
+    ice.lwc_pct_bbl = [0]
+    ice.calculate_refractive_index(input_file)
+    illumination.solzen = 60
+    illumination.calculate_irradiance()
+    for imp in impurities:
+        imp.conc = [0] * ice.nbr_lyr
+
+    ssa_snw, g_snw, mac_snw = get_layer_OPs(ice, model_config)
+    tau, ssa, g, L_snw = mix_in_impurities(ssa_snw, g_snw, mac_snw, ice, impurities, model_config)
+
+    model_config.smooth = False
+    raw = adding_doubling_solver(tau, ssa, g, L_snw, ice, illumination, model_config).albedo.copy()
+
+    model_config.smooth = True
+    smoothed = adding_doubling_solver(tau, ssa, g, L_snw, ice, illumination, model_config).albedo.copy()
+
+    tir = np.isclose(raw, 1.0)
+    assert tir.sum() > 0, "Expected TIR bands at SZA=60 for solid ice (layer_type=1)"
+
+    assert np.all(smoothed[tir] == 1.0), (
+        f"TIR bands distorted by smoothing: min={smoothed[tir].min():.4f} "
+        f"(expected 1.0; was as low as 0.67 before fix)"
+    )
+
+    guard = binary_dilation(tir, iterations=half_w) & ~tir
+    if guard.any():
+        max_dev = np.max(np.abs(smoothed[guard] - raw[guard]))
+        assert max_dev < 0.01, (
+            f"Guard bands falsely elevated: max deviation={max_dev:.4f} "
+            f"(was ~0.33 before fix)"
+        )
+
+    assert np.all((smoothed >= 0.0) & (smoothed <= 1.0))
+
+
+def test_tir_smoothing_no_regression_low_sza():
+    """Regression for #111: at SZA=30 (no TIR), smoothing must be unchanged.
+
+    The TIR guard logic must be a strict no-op when no TIR bands exist, so
+    that standard snow configurations are unaffected by the fix.
+    """
+    from scipy.signal import savgol_filter
+
+    input_file = "biosnicar/inputs.yaml"
+
+    ice, illumination, rt_config, model_config, plot_config, impurities = setup_snicar(
+        input_file
+    )
+    illumination.solzen = 30
+    illumination.calculate_irradiance()
+
+    ssa_snw, g_snw, mac_snw = get_layer_OPs(ice, model_config)
+    tau, ssa, g, L_snw = mix_in_impurities(ssa_snw, g_snw, mac_snw, ice, impurities, model_config)
+
+    model_config.smooth = False
+    raw = adding_doubling_solver(tau, ssa, g, L_snw, ice, illumination, model_config).albedo.copy()
+
+    model_config.smooth = True
+    smoothed = adding_doubling_solver(tau, ssa, g, L_snw, ice, illumination, model_config).albedo.copy()
+
+    assert not np.any(np.isclose(raw, 1.0)), "Unexpected TIR bands at SZA=30"
+
+    # With no TIR bands the guard mask is empty, so output must equal plain SG + clip
+    expected = np.clip(
+        savgol_filter(raw, model_config.window_size, model_config.poly_order), 0.0, 1.0
+    )
+    np.testing.assert_array_equal(smoothed, expected)
+
+
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
closes #111

At oblique solar angles (SZA > ~55°), the direct beam can exceed the critical angle at ice's anomalous-dispersion bands (~2.93–3.09 µm), meaning there is total internal reflection (TIR) causing albedo of 1.0 in those bands (physically correct). The Savitzky-Golay smoothing filter was being applied across these step discontinuities, causing:

  - Undershoot inside the TIR region: bands reported as 0.67–0.95 instead of 1.0
  - False elevation of adjacent bands: non-TIR transition bands reported at ~0.33 instead of ~0.0004

The Matlab reference (Whicker et al. 2022) has no smoothing step and is unaffected.

**Fix (biosnicar/rt_solvers/adding_doubling_solver.py):** 

- the raw solver output is saved before smoothing. A guard zone is built by dilating the TIR mask outward by window_size // 2 bands using scipy.ndimage.binary_dilation. The SG filter is applied to the full spectrum, then raw values are restored within the guard zone so the polynomial is never fitted across the discontinuity. At SZA < ~55° (no TIR), the output is bit-for-bit identical to the previous behaviour.

**Regression tests (tests/test_snicar.py):**

- test_tir_smoothing_high_sza — at SZA=60 with layer_type=1, asserts TIR bands remain exactly 1.0 after smoothing and guard bands deviate < 0.01 from raw values

- test_tir_smoothing_no_regression_low_sza — at SZA=30 (no TIR), asserts smoothed output is identical to plain SG+clip


Note that this is a bug specific to the SMOOTH function, which is optional. 
For absolute consistency with the Matlab equivalents, turn SMOOTH to FALSE in inputs.yaml.

(maybe we just remove the SG filter altogether later, if its more hassle than it's worth)?